### PR TITLE
don't overwrite options.renderer if it's already set

### DIFF
--- a/tasks/marked.js
+++ b/tasks/marked.js
@@ -30,7 +30,9 @@ module.exports = function(grunt) {
             }),
             files = this.files;
 
-        options.renderer = new marked.Renderer();
+        if (!options.renderer) {
+          options.renderer = new marked.Renderer();
+        }
 
         // install highlight.js
         if (options.highlight) {


### PR DESCRIPTION
Custom renderers would allow us to get around [bugs](https://github.com/chjj/marked/pull/317) in marked.