### PR TITLE
added the header stripper as option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,8 +32,16 @@ module.exports = function(grunt) {
     marked: {
       default_options: {
         files: [
-          {src: ['test/fixtures/some.md'], dest: 'tmp/default_options/some.html'}
-        ],
+          {src: ['test/fixtures/some.md'], dest: 'test/expected/some.html'}
+        ]
+      },
+      header:{
+        options:{
+          ignoreheader:true
+        },
+        files: [
+          {src: ['test/fixtures/with_header.md'], dest: 'test/expected/with_header.html'}
+        ]
       }
     },
 

--- a/tasks/marked.js
+++ b/tasks/marked.js
@@ -68,7 +68,7 @@ module.exports = function(grunt) {
 
                 var content = contents.join(os.EOL)
                 if(options.ignoreheader){
-                    var content = content.replace(/---.*[\s\S]+.*?\/---/g, '')
+                    content = content.replace(/---.*[\s\S]+.*?\/---/g, '')
                 }
 
                 grunt.file.write(destination, marked(content));

--- a/tasks/marked.js
+++ b/tasks/marked.js
@@ -26,7 +26,8 @@ module.exports = function(grunt) {
                 sanitize:    true,
                 smartLists:  true,
                 smartypants: false,
-                highlight:   true
+                highlight:   true,
+                ignoreheader: false
             }),
             files = this.files;
 
@@ -65,7 +66,12 @@ module.exports = function(grunt) {
                     return next(err);
                 }
 
-                grunt.file.write(destination, marked(contents.join(os.EOL)));
+                var content = contents.join(os.EOL)
+                if(options.ignoreheader){
+                    var content = content.replace(/---.*[\s\S]+.*?\/---/g, '')
+                }
+
+                grunt.file.write(destination, marked(content));
                 grunt.verbose.writeln(util.format('Successfully rendered markdown to "%s"', destination));
                 next();
             });

--- a/test/expected/with_header.html
+++ b/test/expected/with_header.html
@@ -1,0 +1,3 @@
+<h1 id="test">Test</h1>
+<pre><code class="lang-javascript"><span class="hljs-attribute">var a </span>=<span class="hljs-string"> 10;</span>
+</code></pre>

--- a/test/fixtures/with_header.md
+++ b/test/fixtures/with_header.md
@@ -1,0 +1,11 @@
+---
+title: some title
+/---
+
+
+Test
+====
+
+```javascript
+var a = 10;
+```


### PR DESCRIPTION
So, this strips away an optional header annotation defined like:

```

---
some config info
/---
```

This way you could read the file before convert in html in order to get additional metadata from.
What do you think?
